### PR TITLE
Fix Playwright browser install and improve docker run documentation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -70,10 +70,11 @@ ENV PATH="${JAVA_HOME}/bin:${PATH}"
 # Install Claude Code globally
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 
-# Install Playwright globally with Chromium headless shell (for arm64/amd64)
+# Install Playwright globally with Chromium browser (full + headless shell)
+# Pre-install browsers so they're included in the image and don't need to be downloaded at runtime
 RUN npm install -g playwright \
     && mkdir -p /opt/playwright-browsers \
-    && npx playwright install --with-deps --only-shell chromium \
+    && PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers npx playwright install --with-deps chromium \
     && chmod -R 755 /opt/playwright-browsers
 
 # Configure node user with sudo access
@@ -110,7 +111,8 @@ COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY allowed-domains.conf /usr/local/etc/allowed-domains.conf
 RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/entrypoint.sh
 
-# Set working directory
+# Set working directory and ensure node user owns it
+RUN mkdir -p /workspace && chown node:node /workspace
 WORKDIR /workspace
 
 # Switch to node user
@@ -175,6 +177,8 @@ RUN chmod +x /usr/local/bin/init-firewall.sh \
              /usr/local/bin/entrypoint.sh \
              /usr/local/bin/entrypoint-dind.sh
 
+# Set working directory and ensure node user owns it
+RUN mkdir -p /workspace && chown node:node /workspace
 WORKDIR /workspace
 USER node
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,7 +45,8 @@
     "GH_TOKEN": "${localEnv:GH_TOKEN}",
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
-    "PLAYWRIGHT_CHROMIUM_DEBUG_PORT": "${localEnv:PLAYWRIGHT_CHROMIUM_DEBUG_PORT}"
+    "PLAYWRIGHT_CHROMIUM_DEBUG_PORT": "${localEnv:PLAYWRIGHT_CHROMIUM_DEBUG_PORT}",
+    "PLAYWRIGHT_BROWSERS_PATH": "/opt/playwright-browsers"
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Claude Container Environment Variables
+# Copy this file to .env and customize as needed
+# Usage: docker run --env-file .env ...
+
+# Claude configuration directory (inside container)
+CLAUDE_CONFIG_DIR=/home/node/.claude
+
+# GitHub Personal Access Token for gh CLI
+# GH_TOKEN=ghp_your_token_here
+
+# Timezone (defaults to Europe/Helsinki if not set)
+# TZ=America/New_York
+
+# Skip firewall initialization (set to 1 to disable)
+# SKIP_FIREWALL=0
+
+# Playwright CDP debugging port (leave empty to disable)
+# PLAYWRIGHT_CHROMIUM_DEBUG_PORT=9222
+
+# Playwright browsers path (pre-installed in image)
+PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
+
+# Node.js memory limit
+NODE_OPTIONS=--max-old-space-size=4096

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Environment files (keep .env.example)
+.env
+.env.local
+.env.*.local
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.idea/
+*.swp
+*.swo
+*~
+
+# Build artifacts
+*.log


### PR DESCRIPTION
- Install full Chromium browser instead of headless shell only
- Set PLAYWRIGHT_BROWSERS_PATH during build to ensure correct location
- Add PLAYWRIGHT_BROWSERS_PATH to devcontainer.json containerEnv
- Fix /workspace ownership (now owned by node user)
- Add .env.example with common environment variables
- Add progressive docker run examples with env file support
- Document volume mounts for Maven (.m2-cache) and npm caches
- Add .gitignore for .env files