### PR TITLE
Improve Playwright support and container usability

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,6 +20,7 @@ ENV TZ=${TZ} \
     CLAUDE_CODE_VERSION=${CLAUDE_CODE_VERSION} \
     NODE_PATH=/usr/local/lib/node_modules \
     PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
     PLAYWRIGHT_CHROMIUM_DEBUG_PORT=${PLAYWRIGHT_CHROMIUM_DEBUG_PORT:-}
 
 # Install base dependencies
@@ -43,6 +44,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
     # Port forwarding for Playwright CDP (headless shell only binds to localhost)
     socat \
+    # Playwright browser dependencies (for Java Playwright)
+    libxcursor1 \
+    libgtk-3-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI
@@ -72,10 +76,14 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 
 # Install Playwright globally with Chromium browser (full + headless shell)
 # Pre-install browsers so they're included in the image and don't need to be downloaded at runtime
-# Directory must be writable by node user (Java Playwright needs to create lock files)
 RUN npm install -g playwright \
     && mkdir -p /opt/playwright-browsers \
-    && PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers npx playwright install --with-deps chromium \
+    && PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers npx playwright install --with-deps chromium
+
+# Make npm global directories and Playwright browsers writable by node user
+# This allows Claude to self-update and Java Playwright to create lock files
+RUN chown -R node:node /usr/local/lib/node_modules \
+    && chown -R node:node /usr/local/bin \
     && chown -R node:node /opt/playwright-browsers \
     && chmod -R 755 /opt/playwright-browsers
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,7 +46,8 @@
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
     "PLAYWRIGHT_CHROMIUM_DEBUG_PORT": "${localEnv:PLAYWRIGHT_CHROMIUM_DEBUG_PORT}",
-    "PLAYWRIGHT_BROWSERS_PATH": "/opt/playwright-browsers"
+    "PLAYWRIGHT_BROWSERS_PATH": "/opt/playwright-browsers",
+    "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1"
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",

--- a/.env.example
+++ b/.env.example
@@ -20,5 +20,8 @@ CLAUDE_CONFIG_DIR=/home/node/.claude
 # Playwright browsers path (pre-installed in image)
 PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
 
+# Skip Playwright browser downloads (browsers are pre-installed)
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
 # Node.js memory limit
 NODE_OPTIONS=--max-old-space-size=4096

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -53,6 +53,56 @@ jobs:
             type=sha,prefix=
             type=ref,event=pr
 
+      # Build for local testing first (single platform)
+      - name: Build for testing
+        uses: docker/build-push-action@v6
+        with:
+          context: .devcontainer
+          file: .devcontainer/Dockerfile
+          target: ${{ matrix.variant }}
+          platforms: linux/amd64
+          load: true
+          tags: claude-container:${{ matrix.variant }}-test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Test Playwright in base variant
+      - name: Test Playwright installation
+        if: matrix.variant == 'base'
+        run: |
+          echo "=== Testing Playwright browsers ==="
+          docker run --rm --entrypoint /bin/bash claude-container:base-test -c "
+            echo 'Checking browser directory ownership...'
+            ls -la /opt/playwright-browsers/
+
+            echo ''
+            echo 'Testing lock file creation...'
+            touch /opt/playwright-browsers/__dirlock
+            rm /opt/playwright-browsers/__dirlock
+            echo 'Lock file test passed'
+
+            echo ''
+            echo 'Testing Playwright browser launch...'
+            node -e \"
+              const { chromium } = require('playwright');
+              (async () => {
+                console.log('Launching browser...');
+                const browser = await chromium.launch();
+                console.log('Browser launched successfully');
+                const page = await browser.newPage();
+                await page.goto('https://example.com');
+                const title = await page.title();
+                console.log('Page title:', title);
+                if (!title.includes('Example')) {
+                  throw new Error('Unexpected page title');
+                }
+                await browser.close();
+                console.log('Playwright test passed!');
+              })();
+            \"
+          "
+
+      # Build and push multi-platform images
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/README.md
+++ b/README.md
@@ -408,19 +408,47 @@ firewall-reload
 | `SKIP_FIREWALL` | Set to `1` to skip firewall initialization (useful for DinD troubleshooting) |
 | `FIREWALL_CONFIG` | Custom path to allowed-domains.conf (default: workspace or `/usr/local/etc`) |
 | `DOCKER_HOST` | Docker daemon socket (default: `unix:///var/run/docker.sock`) |
+| `PLAYWRIGHT_BROWSERS_PATH` | Path to pre-installed Playwright browsers (default: `/opt/playwright-browsers`) |
+| `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` | Set to `1` to skip browser downloads (default: `1`, browsers are pre-installed) |
 | `PLAYWRIGHT_CHROMIUM_DEBUG_PORT` | Enable Playwright CDP debugging on specified port (e.g., `9222`). Empty = disabled |
 
-## Playwright Remote Debugging
+## Playwright
+
+The container includes Playwright with Chromium pre-installed, ready to use with both Node.js and Java Playwright libraries.
+
+### Pre-installed Browsers
+
+- **Chromium** (full browser + headless shell)
+- **FFmpeg** (for video recording)
+
+Browsers are installed at `/opt/playwright-browsers` and owned by the `node` user (writable for lock files).
+
+### Java Playwright
+
+The container is configured to work with Java Playwright out of the box:
+
+- `PLAYWRIGHT_BROWSERS_PATH` points to pre-installed browsers
+- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` prevents unnecessary download attempts
+- Required GUI libraries (`libgtk-3`, `libXcursor`) are pre-installed
+
+**Important:** Match your Java Playwright version to the container's Playwright version to use pre-installed browsers:
+
+```bash
+# Check container's Playwright version
+docker run --rm claude-container:base npx playwright --version
+```
+
+### Remote Debugging (CDP)
 
 The container supports Playwright remote debugging via Chrome DevTools Protocol (CDP), allowing you to connect an external Chrome browser to debug Playwright tests running inside the container.
 
-### How It Works
+#### How It Works
 
 The Chromium headless shell only binds to localhost, so the container uses `socat` to forward the debug port:
 - **External port** (0.0.0.0): `PLAYWRIGHT_CHROMIUM_DEBUG_PORT` (e.g., 9222)
 - **Internal port** (127.0.0.1): `PLAYWRIGHT_CDP_INTERNAL_PORT` (automatically set to external + 1, e.g., 9223)
 
-### Quick Start
+#### Quick Start
 
 1. **Start container with debugging enabled:**
    ```bash
@@ -447,7 +475,7 @@ The Chromium headless shell only binds to localhost, so the container uses `soca
    - Click "Configure..." and add `localhost:9222`
    - Your Playwright browser sessions will appear under "Remote Target"
 
-### Usage Examples
+#### Usage Examples
 
 **Quick test script:**
 ```bash
@@ -478,7 +506,7 @@ docker compose exec claude bash  # Then run your Playwright script
 export PLAYWRIGHT_CHROMIUM_DEBUG_PORT=9222
 ```
 
-### Security Note
+#### Security Note
 
 Remote debugging exposes browser internals. Only enable when needed and do not expose port 9222 to untrusted networks.
 


### PR DESCRIPTION
## Summary

- Fix Playwright browser permissions for Java Playwright (lock file creation)
- Add `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` to prevent unnecessary download attempts
- Install missing GUI libraries for Playwright browsers
- Make npm global directories writable so Claude can self-update
- Add CI tests to verify Playwright works correctly
- Improve documentation with docker run examples and env file support

## Changes

### Playwright Fixes
- Changed `/opt/playwright-browsers` ownership to `node:node` (Java Playwright needs to create lock files)
- Added `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` environment variable (prevents Firefox/Webkit download timeouts)
- Installed `libgtk-3-0` and `libxcursor1` for Playwright browser dependencies
- Made `/usr/local/lib/node_modules` and `/usr/local/bin` writable by node user (Claude self-update)

### CI Improvements
- Added Playwright test step that verifies:
  - Browser directory ownership
  - Lock file creation works
  - Chromium can launch and navigate to a page

### Documentation
- Added `.env.example` with all common environment variables
- Added progressive docker run examples (minimal → full setup)
- Documented Maven cache volume mapping (`~/.m2-cache`)
- Added Playwright section with Java Playwright compatibility info
- Updated environment variables table

## Test plan

- [x] Build base image locally
- [x] Verify `/opt/playwright-browsers` owned by node
- [x] Verify lock file can be created
- [x] Verify Playwright can launch browser
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)