### PR TITLE
Pre-install Playwright MCP browsers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -93,6 +93,24 @@ RUN npm install -g playwright \
     && echo "#   <artifactId>playwright</artifactId>" >> /opt/playwright-browsers/VERSION \
     && echo "#   <version>${PLAYWRIGHT_VERSION}</version>" >> /opt/playwright-browsers/VERSION
 
+# Install Playwright MCP and its required browsers (newer version than standard Playwright)
+# This ensures Claude's MCP tools work without downloading browsers at runtime
+# The MCP typically requires a newer Playwright version with a different chromium build
+RUN npm install -g @playwright/mcp \
+    && MCP_PACKAGE_VERSION=$(npm list -g @playwright/mcp --json 2>/dev/null | jq -r '.dependencies["@playwright/mcp"].version // empty') \
+    && MCP_PW_VERSION=$(npm view @playwright/mcp dependencies.playwright 2>/dev/null || echo "") \
+    && if [ -n "$MCP_PW_VERSION" ]; then \
+         echo "Installing MCP Playwright browsers (version ${MCP_PW_VERSION})..." \
+         && PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers npx playwright@${MCP_PW_VERSION} install --with-deps chromium \
+         && echo "" >> /opt/playwright-browsers/VERSION \
+         && echo "# MCP Playwright (for Claude's browser tools):" >> /opt/playwright-browsers/VERSION \
+         && echo "MCP_PACKAGE_VERSION=${MCP_PACKAGE_VERSION}" >> /opt/playwright-browsers/VERSION \
+         && echo "MCP_PLAYWRIGHT_VERSION=${MCP_PW_VERSION}" >> /opt/playwright-browsers/VERSION \
+         && echo "MCP_CHROMIUM_BUILD=$(ls -d /opt/playwright-browsers/chromium-* | tail -1 | xargs basename)" >> /opt/playwright-browsers/VERSION; \
+       else \
+         echo "Warning: Could not determine MCP Playwright version, skipping MCP browser install"; \
+       fi
+
 # Make npm global directories and Playwright browsers writable by node user
 # This allows Claude to self-update and Java Playwright to create lock files
 RUN chown -R node:node /usr/local/lib/node_modules \

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -19,7 +19,13 @@ fi
 if [[ -f /opt/playwright-browsers/VERSION ]]; then
     PW_VER=$(grep "^PLAYWRIGHT_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
     CHROMIUM_BUILD=$(grep "^CHROMIUM_BUILD=" /opt/playwright-browsers/VERSION | cut -d= -f2)
+    MCP_PKG_VER=$(grep "^MCP_PACKAGE_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
+    MCP_PW_VER=$(grep "^MCP_PLAYWRIGHT_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
+    MCP_CHROMIUM_BUILD=$(grep "^MCP_CHROMIUM_BUILD=" /opt/playwright-browsers/VERSION | cut -d= -f2)
     echo "  Playwright:   ${PW_VER} (${CHROMIUM_BUILD})"
+    if [[ -n "${MCP_PW_VER}" ]]; then
+        echo "  MCP:          @playwright/mcp@${MCP_PKG_VER} (${MCP_CHROMIUM_BUILD})"
+    fi
     echo "  Browsers:     ${PLAYWRIGHT_BROWSERS_PATH:-/opt/playwright-browsers}"
 fi
 
@@ -30,6 +36,24 @@ if command -v java &> /dev/null; then
 fi
 
 echo "========================================"
+
+# Show MCP configuration hint if MCP is installed
+if [[ -f /opt/playwright-browsers/VERSION ]]; then
+    MCP_PKG_VER=$(grep "^MCP_PACKAGE_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
+    if [[ -n "${MCP_PKG_VER}" ]]; then
+        echo ""
+        echo "Playwright MCP .mcp.json (use pre-installed browsers):"
+        echo '  "playwright": {'
+        echo '    "command": "npx",'
+        echo '    "args": ['
+        echo "      \"@playwright/mcp@${MCP_PKG_VER}\","
+        echo '      "--headless",'
+        echo '      "--browser",'
+        echo '      "chromium"'
+        echo '    ]'
+        echo '  }'
+    fi
+fi
 echo ""
 
 # Initialize firewall if we have the capability (unless SKIP_FIREWALL is set)

--- a/.devcontainer/playwright-info.sh
+++ b/.devcontainer/playwright-info.sh
@@ -7,7 +7,22 @@ echo "=== Playwright Browser Info ==="
 echo ""
 
 if [ -f "$VERSION_FILE" ]; then
-    grep -v "^#" "$VERSION_FILE" | grep -v "^$"
+    # Standard Playwright
+    PW_VER=$(grep "^PLAYWRIGHT_VERSION=" "$VERSION_FILE" | cut -d= -f2)
+    CHROMIUM_BUILD=$(grep "^CHROMIUM_BUILD=" "$VERSION_FILE" | cut -d= -f2)
+    echo "Standard Playwright: ${PW_VER:-unknown}"
+    echo "  Chromium:          ${CHROMIUM_BUILD:-unknown}"
+
+    # MCP Playwright
+    MCP_PKG_VER=$(grep "^MCP_PACKAGE_VERSION=" "$VERSION_FILE" | cut -d= -f2)
+    MCP_PW_VER=$(grep "^MCP_PLAYWRIGHT_VERSION=" "$VERSION_FILE" | cut -d= -f2)
+    MCP_CHROMIUM_BUILD=$(grep "^MCP_CHROMIUM_BUILD=" "$VERSION_FILE" | cut -d= -f2)
+    if [ -n "$MCP_PW_VER" ]; then
+        echo ""
+        echo "MCP Package:         @playwright/mcp@${MCP_PKG_VER:-unknown}"
+        echo "  Playwright:        ${MCP_PW_VER}"
+        echo "  Chromium:          ${MCP_CHROMIUM_BUILD:-unknown}"
+    fi
     echo ""
 fi
 
@@ -23,4 +38,33 @@ echo ""
 echo "=== Quick Check ==="
 if command -v npx &> /dev/null; then
     echo "Node Playwright: $(npx playwright --version 2>/dev/null || echo 'not available')"
+fi
+
+echo ""
+echo "=== Usage Notes ==="
+echo "- Standard Playwright: For Java Playwright and direct Node.js usage"
+echo "- MCP Playwright: For Claude's browser automation tools (@playwright/mcp)"
+
+# Show recommended .mcp.json if MCP is installed
+if [ -f "$VERSION_FILE" ]; then
+    MCP_PKG_VER=$(grep "^MCP_PACKAGE_VERSION=" "$VERSION_FILE" | cut -d= -f2)
+    if [ -n "$MCP_PKG_VER" ]; then
+        echo ""
+        echo "=== Recommended .mcp.json ==="
+        echo "To use pre-installed browsers (no download at runtime):"
+        echo ""
+        echo '{'
+        echo '  "mcpServers": {'
+        echo '    "playwright": {'
+        echo '      "command": "npx",'
+        echo '      "args": ['
+        echo "        \"@playwright/mcp@${MCP_PKG_VER}\","
+        echo '        "--headless",'
+        echo '        "--browser",'
+        echo '        "chromium"'
+        echo '      ]'
+        echo '    }'
+        echo '  }'
+        echo '}'
+    fi
 fi

--- a/README.md
+++ b/README.md
@@ -418,10 +418,48 @@ The container includes Playwright with Chromium pre-installed, ready to use with
 
 ### Pre-installed Browsers
 
-- **Chromium** (full browser + headless shell)
+The container includes **two versions** of Chromium to support different use cases:
+
+- **Standard Playwright Chromium** (e.g., `chromium-1208`) - For Java Playwright and direct Node.js Playwright usage
+- **MCP Playwright Chromium** (e.g., `chromium-1209`) - For Claude's browser automation tools (`@playwright/mcp`)
 - **FFmpeg** (for video recording)
 
+This dual installation ensures that Claude's MCP browser tools work without downloading browsers at runtime.
+
 Browsers are installed at `/opt/playwright-browsers` and owned by the `node` user (writable for lock files).
+
+### MCP Configuration (.mcp.json)
+
+To use the pre-installed MCP browsers (avoiding downloads at runtime), pin the `@playwright/mcp` version in your `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@0.0.64",
+        "--headless",
+        "--browser",
+        "chromium"
+      ]
+    }
+  }
+}
+```
+
+**Key options:**
+- `@playwright/mcp@X.X.X` - Pin to the installed version (check with `playwright-info`)
+- `--headless` - Run without visible browser UI (recommended for containers)
+- `--browser chromium` - Explicitly use Chromium
+
+**Check the installed MCP version:**
+```bash
+playwright-info
+# Shows: MCP Package: @playwright/mcp@0.0.64
+```
+
+Using `@latest` instead of a pinned version will download new browsers at runtime, which may be slow or fail if the firewall blocks downloads.
 
 ### Java Playwright
 
@@ -444,8 +482,12 @@ cat /opt/playwright-browsers/VERSION
 
 Example output:
 ```
-PLAYWRIGHT_VERSION=1.58.1
-CHROMIUM_BUILD=chromium-1208
+Standard Playwright: 1.58.1
+  Chromium:          chromium-1208
+
+MCP Package:         @playwright/mcp@0.0.64
+  Playwright:        1.59.0-alpha
+  Chromium:          chromium-1209
 ```
 
 Use this version in your Maven `pom.xml`:


### PR DESCRIPTION
## Summary

- Install `@playwright/mcp` and its required browsers during container build
- Both standard Playwright (chromium-1208) and MCP (chromium-1209) now pre-installed
- Add MCP package version to VERSION file for version pinning
- Show recommended `.mcp.json` config in startup message and `playwright-info`
- Document MCP configuration in README

## Why

When Claude uses the Playwright MCP, it requires a newer Playwright version (1.59.0-alpha) than the standard one installed (1.58.1). Without pre-installing the MCP's required browser, it would download at runtime which is slow and may fail if the firewall blocks downloads.

## Changes

The container now shows a recommended `.mcp.json` configuration on startup:

```
Playwright MCP .mcp.json (use pre-installed browsers):
  "playwright": {
    "command": "npx",
    "args": [
      "@playwright/mcp@0.0.64",
      "--headless",
      "--browser",
      "chromium"
    ]
  }
```

## Test plan

- [x] Build container successfully
- [x] Verify both chromium versions installed (`chromium-1208`, `chromium-1209`)
- [x] Test `playwright-info` shows both versions and recommended config
- [x] Test welcome message shows MCP version and config

🤖 Generated with [Claude Code](https://claude.com/claude-code)