### PR TITLE
Add weekly scheduled build and manual dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary
- Adds a weekly cron schedule (Sundays at midnight UTC) to automatically rebuild container images, keeping base images and dependencies up to date
- Adds `workflow_dispatch` trigger to allow manual builds on demand

## Test plan
- [ ] Verify the workflow can be manually triggered via the GitHub Actions "Run workflow" button
- [ ] Confirm the next scheduled run appears in the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)