### PR TITLE
Add Dependabot for Actions and Docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+      day: "sunday"


### PR DESCRIPTION
## Summary
- Adds Dependabot configuration to monitor GitHub Actions and Docker base image for updates
- Scheduled weekly on Sundays, aligned with the existing scheduled container build
- GitHub Actions: catches security patches and major version bumps for the 6 actions used in CI
- Docker: tracks Node.js base image updates (`node:20-bookworm`)

## Test plan
- [ ] Verify Dependabot tab appears in repo settings after merge
- [ ] Confirm Dependabot opens PRs for any available updates within a week

🤖 Generated with [Claude Code](https://claude.com/claude-code)