### PR TITLE
Add default Vaadin and Playwright MCP servers

### DIFF
--- a/.devcontainer/allowed-domains.conf
+++ b/.devcontainer/allowed-domains.conf
@@ -71,8 +71,10 @@ docker.io
 hub.docker.com
 
 # ===========================================
-# Vaadin (uncomment if using Vaadin commercial components)
+# Vaadin
 # ===========================================
+mcp.vaadin.com
+# Uncomment for Vaadin commercial components:
 # maven.vaadin.com
 # tools.vaadin.com
 # vaadin.com

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -4,6 +4,10 @@
 
 set -e
 
+# Ensure CLAUDE_CONFIG_DIR is set so claude CLI writes config to the correct
+# directory (the one that gets bind-mounted / volume-mounted for persistence)
+export CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-/home/node/.claude}"
+
 # Display welcome message with version info
 echo "========================================"
 echo "  Claude Code Container"
@@ -124,11 +128,10 @@ fi
 
 # Configure default MCP servers using claude mcp add-json (user scope)
 # Only adds if not already configured (avoids overwriting user customizations)
-CLAUDE_JSON="${CLAUDE_CONFIG_DIR:-/home/node/.claude}/.claude.json"
 add_mcp_if_missing() {
     local name="$1"
     local json="$2"
-    if [[ -f "${CLAUDE_JSON}" ]] && jq -e ".mcpServers.\"${name}\"" "${CLAUDE_JSON}" > /dev/null 2>&1; then
+    if claude mcp get "${name}" > /dev/null 2>&1; then
         echo "  MCP '${name}' already configured, skipping"
     else
         claude mcp add-json --scope user "${name}" "${json}" 2>/dev/null && \

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -122,6 +122,25 @@ HOOKEOF
     echo "Notification hooks configured for: ${NOTIFICATION_URL}"
 fi
 
+# Configure default MCP servers using claude mcp add-json (user scope)
+# Only adds if not already configured (avoids overwriting user customizations)
+CLAUDE_JSON="${CLAUDE_CONFIG_DIR:-/home/node/.claude}/.claude.json"
+add_mcp_if_missing() {
+    local name="$1"
+    local json="$2"
+    if [[ -f "${CLAUDE_JSON}" ]] && jq -e ".mcpServers.\"${name}\"" "${CLAUDE_JSON}" > /dev/null 2>&1; then
+        echo "  MCP '${name}' already configured, skipping"
+    else
+        claude mcp add-json --scope user "${name}" "${json}" 2>/dev/null && \
+            echo "  MCP '${name}' added" || \
+            echo "  Warning: Failed to add MCP '${name}'"
+    fi
+}
+
+echo "Configuring default MCP servers..."
+add_mcp_if_missing "Vaadin" '{"type":"http","url":"https://mcp.vaadin.com/docs"}'
+add_mcp_if_missing "playwright" '{"command":"npx","args":["@playwright/mcp@latest","--headless","--browser","chromium"]}'
+
 # Initialize firewall if we have the capability (unless SKIP_FIREWALL is set)
 # This requires NET_ADMIN capability to be set
 if [[ "${SKIP_FIREWALL:-0}" == "1" ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,60 @@ jobs:
 
           echo "=== All Vaadin Pro Key tests passed ==="
 
+      # Test default MCP server configuration
+      - name: Test default MCP servers
+        if: matrix.variant == 'base'
+        run: |
+          echo "=== Testing default MCP server provisioning ==="
+
+          # Run the container (entrypoint configures MCPs) and verify with claude mcp list
+          docker run --rm -e SKIP_FIREWALL=1 claude-container:base-test \
+            bash -c '
+              echo "Checking claude mcp list output..."
+              OUTPUT=$(claude mcp list 2>&1)
+              echo "${OUTPUT}"
+
+              echo ""
+              echo "Validating MCP servers..."
+              FAIL=0
+
+              if echo "${OUTPUT}" | grep -q "Vaadin.*Connected"; then
+                echo "PASS: Vaadin MCP connected"
+              else
+                echo "FAIL: Vaadin MCP not connected"
+                FAIL=1
+              fi
+
+              if echo "${OUTPUT}" | grep -q "playwright.*Connected"; then
+                echo "PASS: Playwright MCP connected"
+              else
+                echo "FAIL: Playwright MCP not connected"
+                FAIL=1
+              fi
+
+              exit ${FAIL}
+            '
+
+          echo ""
+          echo "--- Testing idempotency (second run should skip) ---"
+          docker volume create mcp-test-claude
+          # First run: entrypoint adds MCPs
+          docker run --rm -e SKIP_FIREWALL=1 -v mcp-test-claude:/home/node/.claude \
+            claude-container:base-test bash -c 'echo "First run done"'
+          # Second run: same volume, entrypoint should skip
+          docker run --rm -e SKIP_FIREWALL=1 -v mcp-test-claude:/home/node/.claude \
+            claude-container:base-test bash -c 'echo "Second run done"' 2>&1 | tee /tmp/mcp-idempotency.log
+          docker volume rm mcp-test-claude
+
+          if grep -q "already configured" /tmp/mcp-idempotency.log; then
+            echo "PASS: Idempotency check - servers correctly skipped on second run"
+          else
+            echo "FAIL: Idempotency check - servers were re-added instead of skipped"
+            exit 1
+          fi
+
+          echo "=== All MCP server tests passed ==="
+
       # Build and push multi-platform images
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
- Configures Vaadin (HTTP) and Playwright (stdio) MCP servers at container startup via `claude mcp add-json --scope user`
- Idempotent: skips servers already present in `.claude.json` so user customizations aren't overwritten on restart
- Adds `mcp.vaadin.com` to the firewall allowed domains

## Test plan
- [x] Built container image successfully
- [x] Verified `claude mcp list` shows both servers as connected
- [x] Verified idempotency — second entrypoint run skips already-configured servers
- [x] Verified coexistence with notification hooks (separate config files: `.claude.json` for MCPs, `settings.json` for hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)