### PR TITLE
Add OpenCode container variant; switch Claude install to bash; pause dind in CI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -144,14 +144,24 @@ RUN echo '\n# Claude Code aliases' >> /home/node/.zshrc \
 # ========================================
 FROM base-common AS base
 
+# CLAUDE_CODE_VERSION: pass "latest" (default), "stable", or a specific
+# version like "2.1.126". The installer always downloads the newest binary
+# and uses this value to set the active launcher target.
 ARG CLAUDE_CODE_VERSION=latest
 ENV CLAUDE_CODE_VERSION=${CLAUDE_CODE_VERSION}
 
 USER root
 
-# Install Claude Code globally
-RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
-    && chown -R node:node /usr/local/lib/node_modules /usr/local/bin
+# Install Claude Code via the official bash installer.
+# Runs as `node` so the binary lands in /home/node/.local/share/claude/...
+# with a symlink at /home/node/.local/bin/claude. We add a second symlink
+# in /usr/local/bin so the CLI is on PATH for any user.
+RUN if [ "${CLAUDE_CODE_VERSION}" = "latest" ]; then \
+      su - node -c "curl -fsSL https://claude.ai/install.sh | bash"; \
+    else \
+      su - node -c "curl -fsSL https://claude.ai/install.sh | bash -s -- ${CLAUDE_CODE_VERSION}"; \
+    fi \
+    && ln -sf /home/node/.local/bin/claude /usr/local/bin/claude
 
 # Copy firewall, entrypoint, and helper scripts
 COPY init-firewall.sh /usr/local/bin/init-firewall.sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,21 +1,21 @@
-# Claude Code Development Container
+# Coding Agent Development Container
 # Based on the official reference implementation with Java 21 support
-# Multi-stage build supporting base and Docker-in-Docker variants
+# Multi-stage build supporting base (Claude Code), opencode, and Docker-in-Docker variants
 
 ARG NODE_VERSION=20
 ARG VARIANT=base
 
 # ========================================
 # BASE-COMMON STAGE (shared dependencies)
+# Agent-agnostic: tools, Java, Playwright, browsers.
+# Agent CLIs (Claude Code, OpenCode) are added in downstream stages.
 # ========================================
 FROM node:${NODE_VERSION}-bookworm AS base-common
 
 ARG TZ=Europe/Helsinki
-ARG CLAUDE_CODE_VERSION=latest
 
 ENV TZ=${TZ} \
     DEBIAN_FRONTEND=noninteractive \
-    CLAUDE_CODE_VERSION=${CLAUDE_CODE_VERSION} \
     NODE_PATH=/usr/local/lib/node_modules \
     PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers \
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
@@ -72,9 +72,6 @@ RUN mkdir -p /etc/apt/keyrings \
 RUN ln -s /usr/lib/jvm/temurin-21-jdk-* /usr/lib/jvm/temurin-21-jdk
 ENV JAVA_HOME=/usr/lib/jvm/temurin-21-jdk
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
-
-# Install Claude Code globally
-RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 
 # Install Playwright globally with Chromium browser (full + headless shell)
 # Pre-install browsers so they're included in the image and don't need to be downloaded at runtime
@@ -143,11 +140,18 @@ RUN echo '\n# Claude Code aliases' >> /home/node/.zshrc \
     && echo 'SAVEHIST=10000' >> /home/node/.zshrc
 
 # ========================================
-# BASE STAGE (current container)
+# BASE STAGE (Claude Code)
 # ========================================
 FROM base-common AS base
 
+ARG CLAUDE_CODE_VERSION=latest
+ENV CLAUDE_CODE_VERSION=${CLAUDE_CODE_VERSION}
+
 USER root
+
+# Install Claude Code globally
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
+    && chown -R node:node /usr/local/lib/node_modules /usr/local/bin
 
 # Copy firewall, entrypoint, and helper scripts
 COPY init-firewall.sh /usr/local/bin/init-firewall.sh
@@ -169,9 +173,50 @@ ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["/bin/zsh"]
 
 # ========================================
-# DIND STAGE (Docker-in-Docker)
+# OPENCODE STAGE (sst/opencode)
 # ========================================
-FROM base-common AS dind
+FROM base-common AS opencode
+
+# OPENCODE_VERSION: pass "latest" (default) or a specific version like "1.14.33"
+ARG OPENCODE_VERSION=latest
+ENV OPENCODE_VERSION=${OPENCODE_VERSION}
+
+USER root
+
+# Install OpenCode via the official bash installer.
+# Runs as `node` so the binary lands in /home/node/.opencode/bin/opencode,
+# then symlinked into /usr/local/bin for system-wide PATH availability.
+# Tar is already provided by the node:bookworm base image.
+RUN if [ "${OPENCODE_VERSION}" = "latest" ]; then \
+      su - node -c "curl -fsSL https://opencode.ai/install | bash"; \
+    else \
+      su - node -c "curl -fsSL https://opencode.ai/install | bash -s -- --version ${OPENCODE_VERSION}"; \
+    fi \
+    && ln -sf /home/node/.opencode/bin/opencode /usr/local/bin/opencode
+
+# Copy firewall, entrypoint, and helper scripts
+COPY init-firewall.sh /usr/local/bin/init-firewall.sh
+COPY entrypoint-opencode.sh /usr/local/bin/entrypoint.sh
+COPY playwright-info.sh /usr/local/bin/playwright-info
+COPY cdp-proxy-monitor.sh /usr/local/bin/cdp-proxy-monitor
+COPY allowed-domains.conf /usr/local/etc/allowed-domains.conf
+RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/entrypoint.sh /usr/local/bin/playwright-info /usr/local/bin/cdp-proxy-monitor
+
+# Set working directory and ensure node user owns it
+RUN mkdir -p /workspace && chown node:node /workspace
+WORKDIR /workspace
+
+# Switch to node user
+USER node
+
+# Set entrypoint and default command
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["/bin/zsh"]
+
+# ========================================
+# DIND STAGE (Claude Code + Docker-in-Docker)
+# ========================================
+FROM base AS dind
 
 USER root
 

--- a/.devcontainer/allowed-domains.conf
+++ b/.devcontainer/allowed-domains.conf
@@ -7,6 +7,8 @@
 # Core Claude Code domains (required)
 # ===========================================
 api.anthropic.com
+claude.ai
+downloads.claude.ai
 sentry.io
 statsig.anthropic.com
 statsig.com

--- a/.devcontainer/allowed-domains.conf
+++ b/.devcontainer/allowed-domains.conf
@@ -79,5 +79,38 @@ hub.docker.com
 # cdn.vaadin.com
 
 # ===========================================
+# OpenCode (sst/opencode) — required for the opencode variant
+# ===========================================
+opencode.ai
+
+# ===========================================
+# LLM provider APIs (uncomment the ones you use)
+# OpenCode is multi-provider; api.anthropic.com is already allowed above.
+# ===========================================
+# api.openai.com
+# generativelanguage.googleapis.com
+# api.x.ai
+# api.mistral.ai
+# api.groq.com
+# api.deepseek.com
+# api.cohere.ai
+# api.together.xyz
+# openrouter.ai
+# api.fireworks.ai
+# api.perplexity.ai
+# api.cerebras.ai
+
+# ===========================================
+# Local / self-hosted model endpoints
+# (uncomment if running ollama, litellm, vllm, etc. on the host or LAN —
+# 127.0.0.1 is loopback-allowed already; private RFC1918 ranges are
+# allowed by default in init-firewall.sh, so a LAN endpoint typically
+# works without listing it here. Add the host's domain below if you
+# reach it via DNS.)
+# ===========================================
+# ollama.local
+# litellm.local
+
+# ===========================================
 # Custom domains (add your own below)
 # ===========================================

--- a/.devcontainer/devcontainer-opencode.json
+++ b/.devcontainer/devcontainer-opencode.json
@@ -1,0 +1,59 @@
+{
+  "name": "OpenCode Sandbox",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "TZ": "${localEnv:TZ:America/Los_Angeles}",
+      "OPENCODE_VERSION": "latest",
+      "VARIANT": "opencode"
+    },
+    "target": "opencode"
+  },
+  "runArgs": [
+    "--cap-add=NET_ADMIN",
+    "--cap-add=NET_RAW"
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-docker",
+        "eamodio.gitlens",
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "redhat.java",
+        "vscjava.vscode-java-pack",
+        "vscjava.vscode-maven"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "editor.formatOnSave": true,
+        "java.configuration.detectJdksAtStart": true
+      }
+    }
+  },
+  "remoteUser": "node",
+  "mounts": [
+    "source=opencode-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
+    "source=${localEnv:HOME}/.config/opencode,target=/home/node/.config/opencode,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.local/share/opencode,target=/home/node/.local/share/opencode,type=bind,consistency=cached"
+  ],
+  "forwardPorts": [9222],
+  "portsAttributes": {
+    "9222": {
+      "label": "Playwright CDP",
+      "onAutoForward": "silent"
+    }
+  },
+  "containerEnv": {
+    "GH_TOKEN": "${localEnv:GH_TOKEN}",
+    "GIT_USER_NAME": "${localEnv:GIT_USER_NAME}",
+    "GIT_USER_EMAIL": "${localEnv:GIT_USER_EMAIL}",
+    "NODE_OPTIONS": "--max-old-space-size=4096",
+    "PLAYWRIGHT_BROWSERS_PATH": "/opt/playwright-browsers",
+    "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1",
+    "VAADIN_PRO_KEY": "${localEnv:VAADIN_PRO_KEY}"
+  },
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
+  "workspaceFolder": "/workspace",
+  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh"
+}

--- a/.devcontainer/entrypoint-opencode.sh
+++ b/.devcontainer/entrypoint-opencode.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Entrypoint script for OpenCode container
+# Initializes firewall and executes the provided command
+
+set -e
+
+# Display welcome message with version info
+echo "========================================"
+echo "  OpenCode Container"
+echo "========================================"
+
+# Show OpenCode version
+if command -v opencode &> /dev/null; then
+    OPENCODE_VER=$(opencode --version 2>/dev/null | head -1 || echo "unknown")
+    echo "  OpenCode:     ${OPENCODE_VER}"
+fi
+
+# Show Playwright version from VERSION file
+if [[ -f /opt/playwright-browsers/VERSION ]]; then
+    PW_VER=$(grep "^PLAYWRIGHT_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
+    CHROMIUM_BUILD=$(grep "^CHROMIUM_BUILD=" /opt/playwright-browsers/VERSION | cut -d= -f2)
+    MCP_PKG_VER=$(grep "^MCP_PACKAGE_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
+    MCP_PW_VER=$(grep "^MCP_PLAYWRIGHT_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
+    MCP_CHROMIUM_BUILD=$(grep "^MCP_CHROMIUM_BUILD=" /opt/playwright-browsers/VERSION | cut -d= -f2)
+    echo "  Playwright:   ${PW_VER} (${CHROMIUM_BUILD})"
+    if [[ -n "${MCP_PW_VER}" ]]; then
+        echo "  MCP:          @playwright/mcp@${MCP_PKG_VER} (${MCP_CHROMIUM_BUILD})"
+    fi
+    echo "  Browsers:     ${PLAYWRIGHT_BROWSERS_PATH:-/opt/playwright-browsers}"
+fi
+
+# Show Java version
+if command -v java &> /dev/null; then
+    JAVA_VER=$(java -version 2>&1 | head -1 | cut -d'"' -f2)
+    echo "  Java:         ${JAVA_VER}"
+fi
+
+echo "========================================"
+
+# Show MCP configuration hint if MCP is installed
+# OpenCode supports MCP servers via its config file (opencode.json / ~/.config/opencode/config.json)
+if [[ -f /opt/playwright-browsers/VERSION ]]; then
+    MCP_PKG_VER=$(grep "^MCP_PACKAGE_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
+    if [[ -n "${MCP_PKG_VER}" ]]; then
+        echo ""
+        echo "Playwright MCP for OpenCode (add to opencode.json mcp section):"
+        echo '  "playwright": {'
+        echo '    "type": "local",'
+        echo '    "command": ["npx", "@playwright/mcp@'"${MCP_PKG_VER}"'", "--headless", "--browser", "chromium"]'
+        echo '  }'
+    fi
+fi
+echo ""
+
+# Configure git identity if env vars are provided
+if [[ -n "${GIT_USER_NAME:-}" ]]; then
+    git config --global user.name "${GIT_USER_NAME}"
+    echo "Git user.name configured: ${GIT_USER_NAME}"
+fi
+if [[ -n "${GIT_USER_EMAIL:-}" ]]; then
+    git config --global user.email "${GIT_USER_EMAIL}"
+    echo "Git user.email configured: ${GIT_USER_EMAIL}"
+fi
+
+# Initialize firewall if we have the capability (unless SKIP_FIREWALL is set)
+# This requires NET_ADMIN capability to be set
+if [[ "${SKIP_FIREWALL:-0}" == "1" ]]; then
+    echo "SKIP_FIREWALL=1 detected, skipping firewall initialization."
+    echo ""
+elif command -v iptables &> /dev/null; then
+    echo "Initializing firewall..."
+    if sudo /usr/local/bin/init-firewall.sh; then
+        echo "Firewall initialized successfully."
+    else
+        echo "Warning: Firewall initialization failed. Continuing without firewall."
+    fi
+    echo ""
+fi
+
+# Show Chrome DevTools remote debugging hint
+echo "Chrome DevTools (CDT) remote debugging:"
+echo "  Auto-proxy that tracks Playwright's random debug port to 0.0.0.0:9222:"
+echo "  nohup cdp-proxy-monitor > /tmp/cdp-proxy.log 2>&1 &"
+echo "  Then forward port 9222 to your machine and open chrome://inspect"
+echo ""
+
+# Execute the passed command (or default to zsh)
+exec "$@"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,9 @@ jobs:
         include:
           - variant: base
             image_suffix: ""
-          - variant: dind
-            image_suffix: "-dind"
+          # dind variant temporarily disabled — re-enable by uncommenting.
+          # - variant: dind
+          #   image_suffix: "-dind"
           - variant: opencode
             image_suffix: "-opencode"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
             image_suffix: ""
           - variant: dind
             image_suffix: "-dind"
+          - variant: opencode
+            image_suffix: "-opencode"
 
     steps:
       - name: Checkout repository
@@ -71,12 +73,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Test Playwright in base variant
+      # Test Playwright (base + opencode share the playwright layer)
       - name: Test Playwright installation
-        if: matrix.variant == 'base'
+        if: matrix.variant == 'base' || matrix.variant == 'opencode'
         run: |
-          echo "=== Testing Playwright browsers ==="
-          docker run --rm --entrypoint /bin/bash claude-container:base-test -c "
+          echo "=== Testing Playwright browsers (${{ matrix.variant }}) ==="
+          docker run --rm --entrypoint /bin/bash claude-container:${{ matrix.variant }}-test -c "
             echo 'Checking browser directory ownership...'
             ls -la /opt/playwright-browsers/
 
@@ -107,11 +109,11 @@ jobs:
             \"
           "
 
-      # Test Vaadin Pro Key passthrough
+      # Test Vaadin Pro Key passthrough (base + opencode)
       - name: Test Vaadin Pro Key support
-        if: matrix.variant == 'base'
+        if: matrix.variant == 'base' || matrix.variant == 'opencode'
         run: |
-          echo "=== Testing VAADIN_PRO_KEY passthrough ==="
+          echo "=== Testing VAADIN_PRO_KEY passthrough (${{ matrix.variant }}) ==="
           TEST_KEY="test-vaadin-pro-key-12345"
 
           # Test: env var is available inside the container
@@ -119,11 +121,24 @@ jobs:
           docker run --rm \
             -e VAADIN_PRO_KEY="${TEST_KEY}" \
             -e SKIP_FIREWALL=1 \
-            claude-container:base-test \
+            claude-container:${{ matrix.variant }}-test \
             bash -c '[ "${VAADIN_PRO_KEY}" = "'"${TEST_KEY}"'" ]'
           echo "PASS: VAADIN_PRO_KEY env var is set correctly"
 
           echo "=== All Vaadin Pro Key tests passed ==="
+
+      # Test OpenCode CLI is installed and runnable
+      - name: Test OpenCode installation
+        if: matrix.variant == 'opencode'
+        run: |
+          echo "=== Testing OpenCode CLI ==="
+          docker run --rm --entrypoint /bin/bash \
+            -e SKIP_FIREWALL=1 \
+            claude-container:opencode-test -c "
+              command -v opencode || { echo 'opencode not found on PATH'; exit 1; }
+              opencode --version
+            "
+          echo "PASS: opencode CLI is installed"
 
       # Build and push multi-platform images
       - name: Build and push

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,41 @@ services:
     stdin_open: true
     tty: true
 
+  # === OpenCode variant (npm-installed sst/opencode, no DinD) ===
+  opencode:
+    build:
+      context: .devcontainer
+      dockerfile: Dockerfile
+      args:
+        TZ: ${TZ:-Europe/Helsinki}
+        OPENCODE_VERSION: latest
+        VARIANT: opencode
+      target: opencode
+    container_name: opencode-container
+    hostname: opencode-dev
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    volumes:
+      - ${HOME}/.config/opencode:/home/node/.config/opencode:cached
+      - ${HOME}/.local/share/opencode:/home/node/.local/share/opencode:cached
+      - ./:/workspace:delegated
+      - opencode-bashhistory:/commandhistory
+    environment:
+      - TZ=${TZ:-Europe/Helsinki}
+      - GH_TOKEN=${GH_TOKEN}
+      - GIT_USER_NAME=${GIT_USER_NAME:-}
+      - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
+      - NODE_OPTIONS=--max-old-space-size=4096
+      - DEVCONTAINER=true
+      - VAADIN_PRO_KEY=${VAADIN_PRO_KEY:-}
+    ports:
+      - "9222:9222"
+    working_dir: /workspace
+    stdin_open: true
+    tty: true
+
 volumes:
   claude-bashhistory:
   claude-docker-data:
+  opencode-bashhistory:


### PR DESCRIPTION
## Summary
- **New `opencode` build target** — installs `sst/opencode` via the official `opencode.ai` bash installer on top of a refactored `base-common` (Java + Playwright + MCP + browsers stay shared with Claude). Symlinked into `/usr/local/bin/opencode` so the CLI is on PATH for any user. New `entrypoint-opencode.sh`, `devcontainer-opencode.json`, and `opencode` docker-compose service.
- **Claude install switched from npm to the official `claude.ai` bash installer** — same pattern: runs as `node`, lands in `~/.local/share/claude/versions/<v>`, symlinked into `/usr/local/bin/claude`. `CLAUDE_CODE_VERSION` build arg now also accepts `stable` or a specific version. Adds `claude.ai` and `downloads.claude.ai` to the firewall whitelist.
- **`dind` stage now extends `base`** (it was always Claude+Docker semantically; previously relied on Claude being in `base-common`).
- **`dind` variant temporarily disabled in the CI matrix** — Dockerfile stage, `devcontainer-dind.json`, and compose services preserved; re-enable by uncommenting the matrix entry. Existing `ghcr.io/<repo>-dind:latest` on GHCR stays untouched until then.
- **`allowed-domains.conf`** gains `opencode.ai` and a commented opt-in block for OpenAI / Google / xAI / Mistral / Groq / DeepSeek / Cohere / Together / OpenRouter / Fireworks / Perplexity / Cerebras, plus local-model placeholders (ollama / litellm).
- **CI matrix** gains an `opencode` variant with image suffix `-opencode`. Playwright + Vaadin Pro Key tests parameterized to run on both `base` and `opencode`. New `opencode --version` smoke test.

## Local verification
- All three Dockerfile targets (`base`, `dind`, `opencode`) lint clean via `docker buildx --check`.
- Full `docker buildx build --target base` succeeded; `claude --version` → `2.1.126`, `claude --help` and the entrypoint banner render correctly.
- Full `docker buildx build --target opencode` succeeded; `opencode --version` → `1.14.33`, runs first-time SQLite migration, splash + commands render.
- Both entrypoints exit 0 cleanly with `SKIP_FIREWALL=1`.
- `claude -p` with no API key fails with the expected `Not logged in · Please run /login` — confirming the binary loads end-to-end.
- No model-API or live-firewall testing (no keys available); reaching the auth-prompt step is the deepest non-secret-requiring check.

## Test plan
- [ ] CI `base` variant: build + Playwright launch + Vaadin Pro Key passthrough green
- [ ] CI `opencode` variant: build + Playwright launch + Vaadin Pro Key passthrough + `opencode --version` smoke green
- [ ] CI does not run a `dind` matrix leg (commented out)
- [ ] PR build does **not** push to GHCR (`Log in to Container Registry` step shows skipped; `Build and push` shows `push: false`)
- [ ] After merge, `ghcr.io/<repo>:latest` and `ghcr.io/<repo>-opencode:latest` get fresh manifests; `ghcr.io/<repo>-dind:latest` retains its previous push date
- [ ] After merge, smoke-test `docker pull ghcr.io/<repo>:latest && docker run --rm <image> claude --version`
- [ ] After merge, smoke-test `docker pull ghcr.io/<repo>-opencode:latest && docker run --rm <image> opencode --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)