### PR TITLE
Bump GitHub Actions majors (combined #15-#20)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,17 +35,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
           tags: |
@@ -63,7 +63,7 @@ jobs:
 
       # Build for local testing first (single platform)
       - name: Build for testing
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .devcontainer
           file: .devcontainer/Dockerfile
@@ -143,7 +143,7 @@ jobs:
 
       # Build and push multi-platform images
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .devcontainer
           file: .devcontainer/Dockerfile


### PR DESCRIPTION
## Summary
- Combines the 6 open dependabot PRs (#15–#20) into a single branch so one CI run validates all bumps instead of six.
- Each individual dependabot PR already passed CI; this PR exists to land them with a single merge build rather than burning runner time on 6 sequential merge queues.

## Bumps included
- actions/checkout 4 → 6 (closes #15)
- docker/metadata-action 5 → 6 (closes #16)
- docker/setup-buildx-action 3 → 4 (closes #17)
- docker/setup-qemu-action 3 → 4 (closes #18)
- docker/login-action 3 → 4 (closes #19)
- docker/build-push-action 6 → 7 (closes #20)

## Test plan
- [ ] CI workflow `Build and Push Container Images` passes on the `base` matrix variant
- [ ] CI workflow passes on the `opencode` matrix variant
- [ ] Playwright test step still runs successfully under the bumped actions
- [ ] Multi-platform build & push step succeeds on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)