### PR TITLE
Update dind and enable dind builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,8 @@ jobs:
         include:
           - variant: base
             image_suffix: ""
-          # dind variant temporarily disabled — re-enable by uncommenting.
-          # - variant: dind
-          #   image_suffix: "-dind"
+          - variant: dind
+            image_suffix: "-dind"
           - variant: opencode
             image_suffix: "-opencode"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,12 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
+        with:
+          # Pin to the last-good QEMU. binfmt:latest ships QEMU v9, which has a
+          # regression that makes apt segfault / fail ("Cannot allocate memory")
+          # under arm64 emulation — this broke the multi-arch dind build.
+          # See https://github.com/tonistiigi/binfmt/issues/245
+          image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ then create a deccontainer file under `.devcontainer/devcontainer.json` with the
   },
 // If you need docker inside the dev container, does open up options for the AI to do all kinds of things... 
 //  "features": {
-//    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+//    "ghcr.io/devcontainers/features/docker-in-docker:3": {
 //      "version": "latest",
 //      "enableNonRootDocker": "true",
 //      "moby": "false"


### PR DESCRIPTION
This pull request re-enables support for the Docker-in-Docker (dind) variant in the build workflow and updates the recommended version of the Docker-in-Docker feature in the development container setup instructions.

**Build workflow changes:**

* Re-enabled the `dind` (Docker-in-Docker) build variant in the `.github/workflows/build.yml` file, allowing builds that require Docker-in-Docker support.

**Development container setup:**

* Updated the commented example in `README.md` to recommend version 3 of the `ghcr.io/devcontainers/features/docker-in-docker` feature instead of version 2.