### PR TITLE
ci: disable matrix fail-fast so one flaky variant doesn't cancel others

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,10 @@ jobs:
       packages: write
 
     strategy:
+      # Don't let one flaky variant cancel the others. Each variant is an
+      # independent image, so a transient failure in (e.g.) the opencode build
+      # shouldn't take down the otherwise-healthy base and dind builds.
+      fail-fast: false
       matrix:
         include:
           - variant: base


### PR DESCRIPTION
## What

Sets `fail-fast: false` on the `build-and-test` matrix strategy.

## Why

The [2026-06-28 weekly build](https://github.com/petrixh/claude-container/actions/runs/28310835680) went fully red, but only **one** job actually failed: the `opencode` variant hit a transient `Failed to fetch version information` error during the emulated **arm64** OpenCode install (the installer's unauthenticated `api.github.com` version lookup returned nothing). With the default fail-fast behavior, that single failure **cancelled the otherwise-healthy `base` and `dind` jobs**, so no images published that week.

Each matrix variant is an independent image. A transient flake in one variant should not take down the others.

## Effect

- A flaky variant now fails in isolation; the healthy variants still build and publish.
- This intentionally does **not** try to prevent the opencode flake itself — keeping the change minimal. If opencode keeps flaking over the coming weeks, the follow-up is to wrap its installer in a retry. Pinning + dependabot was considered and rejected, as it works against the "fresh-every-Monday, zero-touch" design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)