### PR TITLE
Remove the deprecated Playwright MCP from the container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -92,31 +92,13 @@ RUN npm install -g playwright \
     && echo "#   <artifactId>playwright</artifactId>" >> /opt/playwright-browsers/VERSION \
     && echo "#   <version>${PLAYWRIGHT_VERSION}</version>" >> /opt/playwright-browsers/VERSION
 
-# Install Playwright MCP and its required browsers (newer version than standard Playwright)
-# This ensures Claude's MCP tools work without downloading browsers at runtime
-# The MCP typically requires a newer Playwright version with a different chromium build
-RUN npm install -g @playwright/mcp \
-    && MCP_PACKAGE_VERSION=$(npm list -g @playwright/mcp --json 2>/dev/null | jq -r '.dependencies["@playwright/mcp"].version // empty') \
-    && MCP_PW_VERSION=$(npm view @playwright/mcp dependencies.playwright 2>/dev/null || echo "") \
-    && if [ -n "$MCP_PW_VERSION" ]; then \
-         echo "Installing MCP Playwright browsers (version ${MCP_PW_VERSION})..." \
-         && PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers npx playwright@${MCP_PW_VERSION} install --with-deps chromium \
-         && echo "" >> /opt/playwright-browsers/VERSION \
-         && echo "# MCP Playwright (for Claude's browser tools):" >> /opt/playwright-browsers/VERSION \
-         && echo "MCP_PACKAGE_VERSION=${MCP_PACKAGE_VERSION}" >> /opt/playwright-browsers/VERSION \
-         && echo "MCP_PLAYWRIGHT_VERSION=${MCP_PW_VERSION}" >> /opt/playwright-browsers/VERSION \
-         && echo "MCP_CHROMIUM_BUILD=$(ls -d /opt/playwright-browsers/chromium-* | tail -1 | xargs basename)" >> /opt/playwright-browsers/VERSION; \
-       else \
-         echo "Warning: Could not determine MCP Playwright version, skipping MCP browser install"; \
-       fi
-
 # Install the Playwright Agent CLI (@playwright/cli) and its required browser.
-# This is a lower-token, less-flaky alternative to the MCP server: coding agents
-# drive the browser with `playwright-cli` shell commands instead of MCP tool
-# calls (no tool schemas / snapshots held in context). It bundles its own, newer
-# playwright-core, so it needs its own chromium build pre-installed here to avoid
-# a runtime download (which the firewall would block). The agent-facing skill is
-# installed further down, once the node user's home directory exists.
+# Coding agents drive the browser with `playwright-cli` shell commands and concise
+# output (no tool schemas / page snapshots held in context), which is fast and
+# token-efficient. It bundles its own, newer playwright-core, so it needs its own
+# chromium build pre-installed here to avoid a runtime download (which the firewall
+# would block). The agent-facing skill is installed further down, once the node
+# user's home directory exists.
 RUN npm install -g @playwright/cli \
     && CLI_PACKAGE_VERSION=$(npm list -g @playwright/cli --json 2>/dev/null | jq -r '.dependencies["@playwright/cli"].version // empty') \
     && PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers playwright-cli install-browser chromium --with-deps \

--- a/.devcontainer/entrypoint-opencode.sh
+++ b/.devcontainer/entrypoint-opencode.sh
@@ -19,15 +19,9 @@ fi
 if [[ -f /opt/playwright-browsers/VERSION ]]; then
     PW_VER=$(grep "^PLAYWRIGHT_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
     CHROMIUM_BUILD=$(grep "^CHROMIUM_BUILD=" /opt/playwright-browsers/VERSION | cut -d= -f2)
-    MCP_PKG_VER=$(grep "^MCP_PACKAGE_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
-    MCP_PW_VER=$(grep "^MCP_PLAYWRIGHT_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
-    MCP_CHROMIUM_BUILD=$(grep "^MCP_CHROMIUM_BUILD=" /opt/playwright-browsers/VERSION | cut -d= -f2)
     CLI_PKG_VER=$(grep "^CLI_PACKAGE_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
     CLI_CHROMIUM_BUILD=$(grep "^CLI_CHROMIUM_BUILD=" /opt/playwright-browsers/VERSION | cut -d= -f2)
     echo "  Playwright:   ${PW_VER} (${CHROMIUM_BUILD})"
-    if [[ -n "${MCP_PW_VER}" ]]; then
-        echo "  MCP:          @playwright/mcp@${MCP_PKG_VER} (${MCP_CHROMIUM_BUILD})"
-    fi
     if [[ -n "${CLI_PKG_VER}" ]]; then
         echo "  Agent CLI:    @playwright/cli@${CLI_PKG_VER} (${CLI_CHROMIUM_BUILD})"
     fi
@@ -42,26 +36,14 @@ fi
 
 echo "========================================"
 
-# Show browser-automation hints. The Agent CLI is the recommended path; the
-# MCP server is deprecated and printed only as a fallback for existing setups.
-# (OpenCode supports MCP servers via opencode.json / ~/.config/opencode/config.json.)
+# Show browser-automation hint for the Playwright Agent CLI.
 if [[ -f /opt/playwright-browsers/VERSION ]]; then
     CLI_PKG_VER=$(grep "^CLI_PACKAGE_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
     if [[ -n "${CLI_PKG_VER}" ]]; then
         echo ""
-        echo "Playwright Agent CLI (recommended — faster, lower token use):"
+        echo "Playwright Agent CLI (browser automation — faster, lower token use):"
         echo "  Skill pre-installed at ~/.claude/skills/playwright-cli — OpenCode discovers it automatically."
         echo "  Drive a browser directly, e.g.: playwright-cli open && playwright-cli goto https://example.com"
-    fi
-    MCP_PKG_VER=$(grep "^MCP_PACKAGE_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
-    if [[ -n "${MCP_PKG_VER}" ]]; then
-        echo ""
-        echo "Playwright MCP (DEPRECATED — prefer the Agent CLI above; will be removed in a future release)."
-        echo "  Add to opencode.json mcp section:"
-        echo '  "playwright": {'
-        echo '    "type": "local",'
-        echo '    "command": ["npx", "@playwright/mcp@'"${MCP_PKG_VER}"'", "--headless", "--browser", "chromium"]'
-        echo '  }'
     fi
 fi
 echo ""

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -19,15 +19,9 @@ fi
 if [[ -f /opt/playwright-browsers/VERSION ]]; then
     PW_VER=$(grep "^PLAYWRIGHT_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
     CHROMIUM_BUILD=$(grep "^CHROMIUM_BUILD=" /opt/playwright-browsers/VERSION | cut -d= -f2)
-    MCP_PKG_VER=$(grep "^MCP_PACKAGE_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
-    MCP_PW_VER=$(grep "^MCP_PLAYWRIGHT_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
-    MCP_CHROMIUM_BUILD=$(grep "^MCP_CHROMIUM_BUILD=" /opt/playwright-browsers/VERSION | cut -d= -f2)
     CLI_PKG_VER=$(grep "^CLI_PACKAGE_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
     CLI_CHROMIUM_BUILD=$(grep "^CLI_CHROMIUM_BUILD=" /opt/playwright-browsers/VERSION | cut -d= -f2)
     echo "  Playwright:   ${PW_VER} (${CHROMIUM_BUILD})"
-    if [[ -n "${MCP_PW_VER}" ]]; then
-        echo "  MCP:          @playwright/mcp@${MCP_PKG_VER} (${MCP_CHROMIUM_BUILD})"
-    fi
     if [[ -n "${CLI_PKG_VER}" ]]; then
         echo "  Agent CLI:    @playwright/cli@${CLI_PKG_VER} (${CLI_CHROMIUM_BUILD})"
     fi
@@ -42,30 +36,14 @@ fi
 
 echo "========================================"
 
-# Show browser-automation hints. The Agent CLI is the recommended path; the
-# MCP server is deprecated and printed only as a fallback for existing setups.
+# Show browser-automation hint for the Playwright Agent CLI.
 if [[ -f /opt/playwright-browsers/VERSION ]]; then
     CLI_PKG_VER=$(grep "^CLI_PACKAGE_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
     if [[ -n "${CLI_PKG_VER}" ]]; then
         echo ""
-        echo "Playwright Agent CLI (recommended — faster, lower token use):"
+        echo "Playwright Agent CLI (browser automation — faster, lower token use):"
         echo "  Skill pre-installed at ~/.claude/skills/playwright-cli — Claude loads it on demand."
         echo "  Drive a browser directly, e.g.: playwright-cli open && playwright-cli goto https://example.com"
-    fi
-    MCP_PKG_VER=$(grep "^MCP_PACKAGE_VERSION=" /opt/playwright-browsers/VERSION | cut -d= -f2)
-    if [[ -n "${MCP_PKG_VER}" ]]; then
-        echo ""
-        echo "Playwright MCP (DEPRECATED — prefer the Agent CLI above; will be removed in a future release)."
-        echo "  .mcp.json (use pre-installed browsers):"
-        echo '  "playwright": {'
-        echo '    "command": "npx",'
-        echo '    "args": ['
-        echo "      \"@playwright/mcp@${MCP_PKG_VER}\","
-        echo '      "--headless",'
-        echo '      "--browser",'
-        echo '      "chromium"'
-        echo '    ]'
-        echo '  }'
     fi
 fi
 echo ""

--- a/.devcontainer/playwright-info.sh
+++ b/.devcontainer/playwright-info.sh
@@ -13,17 +13,6 @@ if [ -f "$VERSION_FILE" ]; then
     echo "Standard Playwright: ${PW_VER:-unknown}"
     echo "  Chromium:          ${CHROMIUM_BUILD:-unknown}"
 
-    # MCP Playwright
-    MCP_PKG_VER=$(grep "^MCP_PACKAGE_VERSION=" "$VERSION_FILE" | cut -d= -f2)
-    MCP_PW_VER=$(grep "^MCP_PLAYWRIGHT_VERSION=" "$VERSION_FILE" | cut -d= -f2)
-    MCP_CHROMIUM_BUILD=$(grep "^MCP_CHROMIUM_BUILD=" "$VERSION_FILE" | cut -d= -f2)
-    if [ -n "$MCP_PW_VER" ]; then
-        echo ""
-        echo "MCP Package:         @playwright/mcp@${MCP_PKG_VER:-unknown}"
-        echo "  Playwright:        ${MCP_PW_VER}"
-        echo "  Chromium:          ${MCP_CHROMIUM_BUILD:-unknown}"
-    fi
-
     # Playwright Agent CLI
     CLI_PKG_VER=$(grep "^CLI_PACKAGE_VERSION=" "$VERSION_FILE" | cut -d= -f2)
     CLI_CHROMIUM_BUILD=$(grep "^CLI_CHROMIUM_BUILD=" "$VERSION_FILE" | cut -d= -f2)
@@ -53,32 +42,6 @@ fi
 echo ""
 echo "=== Usage Notes ==="
 echo "- Standard Playwright: For Java Playwright and direct Node.js usage"
-echo "- Agent CLI (@playwright/cli): RECOMMENDED for agent browser automation —"
+echo "- Agent CLI (@playwright/cli): For agent browser automation —"
 echo "    faster, lower token use. Pre-installed skill: ~/.claude/skills/playwright-cli"
 echo "    (run 'playwright-cli --help')"
-echo "- MCP Playwright (@playwright/mcp): DEPRECATED — prefer the Agent CLI;"
-echo "    kept for a grace period, will be removed from the container in a future release"
-
-# Show the .mcp.json snippet if MCP is installed (deprecated — for existing setups)
-if [ -f "$VERSION_FILE" ]; then
-    MCP_PKG_VER=$(grep "^MCP_PACKAGE_VERSION=" "$VERSION_FILE" | cut -d= -f2)
-    if [ -n "$MCP_PKG_VER" ]; then
-        echo ""
-        echo "=== .mcp.json (DEPRECATED — prefer the Agent CLI) ==="
-        echo "To use pre-installed browsers (no download at runtime):"
-        echo ""
-        echo '{'
-        echo '  "mcpServers": {'
-        echo '    "playwright": {'
-        echo '      "command": "npx",'
-        echo '      "args": ['
-        echo "        \"@playwright/mcp@${MCP_PKG_VER}\","
-        echo '        "--headless",'
-        echo '        "--browser",'
-        echo '        "chromium"'
-        echo '      ]'
-        echo '    }'
-        echo '  }'
-        echo '}'
-    fi
-fi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       - dependencies
       - github-actions
 
-  # Note: npm packages installed inside the container (playwright, @playwright/mcp,
+  # Note: npm packages installed inside the container (playwright, @playwright/cli,
   # opencode-ai, claude install script) are intentionally NOT tracked here. They are
   # pulled fresh on every image build, and the workflow runs weekly on cron, so the
   # next image rebuild always uses the latest versions without dependabot churn.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,32 @@ jobs:
             "
           echo "PASS: opencode CLI is installed"
 
+      # Test the Playwright Agent CLI is installed, the skill is baked in, and it
+      # can launch the pre-installed Chromium offline (no runtime browser download).
+      - name: Test Playwright Agent CLI
+        if: matrix.variant == 'base' || matrix.variant == 'opencode'
+        run: |
+          echo "=== Testing Playwright Agent CLI (${{ matrix.variant }}) ==="
+          docker run --rm --entrypoint /bin/bash \
+            -e SKIP_FIREWALL=1 \
+            claude-container:${{ matrix.variant }}-test -c '
+              set -e
+              command -v playwright-cli || { echo "playwright-cli not found on PATH"; exit 1; }
+              playwright-cli --version
+
+              echo "Checking pre-installed skill..."
+              test -f /home/node/.claude/skills/playwright-cli/SKILL.md \
+                || { echo "skill SKILL.md not found"; exit 1; }
+
+              echo "Launching pre-installed browser (offline data: URL)..."
+              playwright-cli open
+              playwright-cli goto "data:text/html,<h1>cli-ok</h1>"
+              playwright-cli snapshot | grep -q "cli-ok" \
+                || { echo "expected heading not found in snapshot"; exit 1; }
+              playwright-cli close
+            '
+          echo "PASS: playwright-cli is installed, skill present, browser launches"
+
       # Build and push multi-platform images
       - name: Build and push
         uses: docker/build-push-action@v7

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ docker run -it --rm \
 
 Clone your projects under `/workspace`, run claude do stuff :) 
 
-Read what the `entrypoint.sh` command tells you about versions if wou want to use built-in predownloaded browers, playwright MCP in headless mode etc. Or don't... you can re-run the entrypoint inside the container terminal by just typing `entrypoint.sh` to get to the info later also (should be fine to rerun). To update claude run `sudo claude update` as new versions are being pushed constantly... 
+Read what the `entrypoint.sh` command tells you about versions if wou want to use built-in predownloaded browers, the Playwright Agent CLI etc. Or don't... you can re-run the entrypoint inside the container terminal by just typing `entrypoint.sh` to get to the info later also (should be fine to rerun). To update claude run `sudo claude update` as new versions are being pushed constantly... 
 
 # TL;DR I just want a devcontainer from my IDE/Codespaces optinally with docker-in-docker fully understanding the risks it might bring
 
@@ -199,7 +199,7 @@ NODE_OPTIONS=--max-old-space-size=4096
 
 If you had the folder open in VS Code, it should have already prompted you that a devcotnainer config was found. If not open the command palette and with > at the front look for "Dev Containers: Rebuild and Reopend in Container". It will download the internet and reopen the folder inside the devcotnaienr in VS Code. 
 
-Read what the `entrypoint.sh` command tells you about versions if wou want to use built-in predownloaded browers, playwright MCP in headless mode etc. Or don't... you can re-run the entrypoint inside the container terminal by just typing `entrypoint.sh` to get to the info later also (should be fine to rerun). To update claude run `sudo claude update` as new versions are being pushed constantly... 
+Read what the `entrypoint.sh` command tells you about versions if wou want to use built-in predownloaded browers, the Playwright Agent CLI etc. Or don't... you can re-run the entrypoint inside the container terminal by just typing `entrypoint.sh` to get to the info later also (should be fine to rerun). To update claude run `sudo claude update` as new versions are being pushed constantly... 
 
 ## Separate devcontainer and workspaces
 
@@ -727,17 +727,16 @@ The container includes Playwright with Chromium pre-installed, ready to use with
 The container includes **multiple versions** of Chromium to support different use cases:
 
 - **Standard Playwright Chromium** (e.g., `chromium-1208`) - For Java Playwright and direct Node.js Playwright usage
-- **Agent CLI Chromium** (e.g., `chromium-1210`) - For the Playwright Agent CLI (`@playwright/cli`, recommended for agents)
-- **MCP Playwright Chromium** (e.g., `chromium-1209`) - For Claude's browser automation tools (`@playwright/mcp`, deprecated)
+- **Agent CLI Chromium** (e.g., `chromium-1210`) - For the Playwright Agent CLI (`@playwright/cli`), used by agents for browser automation
 - **FFmpeg** (for video recording)
 
 Pre-installing each ensures the browser automation tooling works without downloading browsers at runtime.
 
 Browsers are installed at `/opt/playwright-browsers` and owned by the `node` user (writable for lock files).
 
-### Browser Automation for Agents — Playwright Agent CLI (recommended)
+### Browser Automation for Agents (Playwright Agent CLI)
 
-The recommended way for an agent to drive a browser is the [Playwright Agent CLI](https://playwright.dev/agent-cli/introduction) (`@playwright/cli`). The agent runs plain `playwright-cli` shell commands with concise output and loads skills on demand, instead of calling MCP tools whose schemas and page snapshots sit in the context window. In practice it is **faster and uses fewer tokens** than the MCP server.
+Agents drive a browser with the [Playwright Agent CLI](https://playwright.dev/agent-cli/introduction) (`@playwright/cli`): the agent runs plain `playwright-cli` shell commands with concise output and loads skills on demand. Because tool schemas and page snapshots don't sit in the context window, it's **fast and token-efficient**.
 
 **Pre-installed skill (no setup needed).** The agent-facing skill is baked into the image at `~/.claude/skills/playwright-cli`. Claude Code loads personal skills from `~/.claude/skills`, and OpenCode also discovers skills there, so both agents pick it up automatically in any project — without touching your mounted workspace.
 
@@ -752,41 +751,6 @@ playwright-cli --help                        # full command list
 ```
 
 To instead install the skill into a specific project (committed to the repo), run `playwright-cli install --skills claude` (or `--skills agents` for the agent-agnostic `.agents/skills` location).
-
-### Playwright MCP (deprecated)
-
-> **Deprecated.** The `@playwright/mcp` server is still installed and works, but the [Playwright Agent CLI](#browser-automation-for-agents--playwright-agent-cli-recommended) above is now the recommended approach. The MCP is kept for a short grace period and will be **removed from the container** in a future release — see [#27](https://github.com/petrixh/claude-container/issues/27). New setups should use the Agent CLI.
-
-To use the pre-installed MCP browsers (avoiding downloads at runtime), pin the `@playwright/mcp` version in your `.mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": [
-        "@playwright/mcp@0.0.64",
-        "--headless",
-        "--browser",
-        "chromium"
-      ]
-    }
-  }
-}
-```
-
-**Key options:**
-- `@playwright/mcp@X.X.X` - Pin to the installed version (check with `playwright-info`)
-- `--headless` - Run without visible browser UI (recommended for containers)
-- `--browser chromium` - Explicitly use Chromium
-
-**Check the installed MCP version:**
-```bash
-playwright-info
-# Shows: MCP Package: @playwright/mcp@0.0.64
-```
-
-Using `@latest` instead of a pinned version will download new browsers at runtime, which may be slow or fail if the firewall blocks downloads.
 
 ### Java Playwright
 
@@ -811,10 +775,6 @@ Example output:
 ```
 Standard Playwright: 1.58.1
   Chromium:          chromium-1208
-
-MCP Package:         @playwright/mcp@0.0.64
-  Playwright:        1.59.0-alpha
-  Chromium:          chromium-1209
 
 Agent CLI:           @playwright/cli@0.1.14
   Chromium:          chromium-1210
@@ -870,7 +830,7 @@ Hand this to your agent — it just needs to add the two flags wherever it launc
 2. Open `chrome://inspect`, click **Configure…**, and add `localhost:9222`.
 3. The agent-controlled browser appears as a remote target.
 
-> **Note:** Earlier images relied on the deprecated Playwright MCP plus a `cdp-proxy-monitor` socat bridge. The MCP is [deprecated](#playwright-mcp-deprecated) and the proxy is no longer needed with the fixed-port approach above.
+> **Note:** Earlier images relied on the Playwright MCP plus a `cdp-proxy-monitor` socat bridge. Both have been removed in favor of the Agent CLI and the fixed-port approach above.
 
 #### Security Note
 


### PR DESCRIPTION
> **Draft — for testing, not for merging yet.** Opened as a draft so CI exercises the multi-arch build while the MCP keeps its grace period. Mark ready / merge later once the grace window closes.

Closes #27.

## What

Removes the deprecated `@playwright/mcp` server and everything tied to it. The [Playwright Agent CLI](https://playwright.dev/agent-cli/introduction) (added in #26) is now the sole browser-automation path for agents.

## Changes

- **Dockerfile**: drop the `@playwright/mcp` install block and its dedicated chromium layer — the image now carries only the standard Playwright browser + the Agent CLI browser. Reworded the Agent CLI comment so it no longer references the MCP.
- **`entrypoint.sh` / `entrypoint-opencode.sh`**: remove the `MCP:` version line and the deprecated-MCP hint block; the Agent CLI hint stays.
- **`playwright-info.sh`**: remove the MCP version display, the usage note, and the `.mcp.json` snippet.
- **`README.md`**: drop the "Playwright MCP (deprecated)" section, the MCP entry in the pre-installed browser list, and the MCP lines in the example VERSION output; update the CDP note and the two casual mentions.
- **`dependabot.yml`**: update the not-tracked note (`@playwright/mcp` → `@playwright/cli`).

Net: **+18 / −153**.

## Verification (local, linux/arm64 base build)

- `npm ls -g @playwright/mcp` → absent
- `/opt/playwright-browsers/VERSION` → zero `MCP_` lines; only standard Playwright + `CLI_*`
- only two chromium builds remain (standard + Agent CLI); CLI chromium-build detection still resolves correctly
- `playwright-cli` + its pre-installed `~/.claude/skills/playwright-cli` skill still launch a browser and return a snapshot (`open`→`goto`→`snapshot`→`close`)

## Note for reviewers

Anyone still pinning `@playwright/mcp` in a `.mcp.json` / `opencode.json` must switch to the Agent CLI (see the README "Browser Automation for Agents" section) before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)